### PR TITLE
query for adjust webhook url by name

### DIFF
--- a/adjust
+++ b/adjust
@@ -73,13 +73,12 @@ query {{
 
 query_webhook_url = """
 query {{
-  triggers(limit:10, filters: {{application: {{operator:EQUALS, values: "{}"}}, }}) {{
-    nodes {{
-      condition {{
-        ... on OnWebhook {{
-          webhookDetails {{
-            webhookURL
-          }}
+  triggerByName(applicationId:"{}",triggerName: "opsani-canary-update") {{
+    id
+    condition {{
+      ... on OnWebhook {{
+        webhookDetails {{
+          webhookURL
         }}
       }}
     }}


### PR DESCRIPTION
We were just grabbing the first one on the list of triggers (which worked when we only had 1 webhook configured) but is not ideal as stack owners may have additional webhooks.  With this, the webhook is hardcoded to be "opsani-canary-update" but is not final (will be moving to tuning instance verbiage before wider rollout) 